### PR TITLE
Fix column addresses, CDATA escaping, named ranges and test hermeticity

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ You might not want to use cell addresses in your formulas because they are not s
 You may use [named ranges](https://help.libreoffice.org/6.2/en-US/text/scalc/01/04070000.html) to help with that.
 
 You may create a named range by applying the `range` property in one or multiple cells.
-If you apply the same name to multiple cells they need to be contiguous.
+If you apply the same name to multiple cells they need to be contiguous, that is they have to fill a complete rectangle of cells.
+Applying the same name to cells which do not is rejected with an error rather than silently widened to the surrounding rectangle.
 
 Usage example:
 

--- a/__tests__/spreadsheet-builder.spec.ts
+++ b/__tests__/spreadsheet-builder.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@jest/globals";
 import { exec } from "child_process";
 import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { resolve } from "path";
 import { promisify } from "util";
 import { buildSpreadsheet, spreadsheetInput, columnIndex, A1 } from "../src";
 
@@ -37,12 +38,77 @@ describe("Unit tests", () => {
     expect(columnIndex(4)).toEqual("D");
   });
 
+  test("column index beyond Z", async () => {
+    expect(columnIndex(26)).toEqual("Z");
+    expect(columnIndex(27)).toEqual("AA");
+    expect(columnIndex(28)).toEqual("AB");
+    expect(columnIndex(52)).toEqual("AZ");
+    expect(columnIndex(53)).toEqual("BA");
+    expect(columnIndex(702)).toEqual("ZZ");
+    expect(columnIndex(703)).toEqual("AAA");
+  });
+
+  test("A1 Addressing beyond column Z", async () => {
+    expect(A1(27, 1)).toEqual("AA1");
+    expect(A1(30, 1)).toEqual("AD1");
+    expect(A1(703, 12, "columnAndRow")).toEqual("$AAA$12");
+  });
+
   test("A1 Addressing", async () => {
     expect(A1(1, 1)).toEqual("A1");
     expect(A1(2, 1)).toEqual("B1");
     expect(A1(3, 1)).toEqual("C1");
     expect(A1(1, 2)).toEqual("A2");
     expect(A1(1, 3)).toEqual("A3");
+  });
+
+  test("a string cell containing the CDATA terminator stays well formed", async () => {
+    const actual = await buildSpreadsheet([["a]]> b"], [{ value: "c]]> d" }]]);
+
+    // the terminator has to be split across two CDATA sections
+    expect(actual).toMatch("<text:p><![CDATA[a]]]]><![CDATA[> b]]></text:p>");
+    expect(actual).toMatch("<text:p><![CDATA[c]]]]><![CDATA[> d]]></text:p>");
+
+    // and no section may be closed before its cell ends
+    expect(actual).not.toMatch("<![CDATA[a]]> b");
+    expect(actual).not.toMatch("<![CDATA[c]]> d");
+  });
+
+  test("range names are escaped when interpolated into attributes", async () => {
+    const actual = await buildSpreadsheet([[{ value: "1", valueType: "float", range: `a"&<b` }]]);
+
+    expect(actual).toMatch('<table:named-range table:name="a&quot;&amp;&lt;b"');
+  });
+
+  test("a range named 'undefined' is not dropped", async () => {
+    const actual = await buildSpreadsheet([[{ value: "1", valueType: "float", range: "undefined" }]]);
+
+    expect(actual).toMatch('<table:named-range table:name="undefined" table:base-cell-address="$Sheet1.$A$1" table:cell-range-address="$Sheet1.$A$1"/>');
+  });
+
+  test("a named range spanning a rectangle uses its bounding box", async () => {
+    const actual = await buildSpreadsheet([
+      [
+        { value: "1", valueType: "float", range: "block" },
+        { value: "2", valueType: "float", range: "block" },
+      ],
+      [
+        { value: "3", valueType: "float", range: "block" },
+        { value: "4", valueType: "float", range: "block" },
+      ],
+    ]);
+
+    expect(actual).toMatch('<table:named-range table:name="block" table:base-cell-address="$Sheet1.$A$1" table:cell-range-address="$Sheet1.$A$1:.$B$2"/>');
+  });
+
+  test("a non-contiguous named range is rejected instead of silently widened", async () => {
+    const input: spreadsheetInput = [
+      [{ value: "1", valueType: "float", range: "scattered" }, "b", "c"],
+      ["d", "e", "f"],
+      ["g", "h", { value: "2", valueType: "float", range: "scattered" }],
+    ];
+
+    await expect(buildSpreadsheet(input)).rejects.toThrow(/scattered/);
   });
 
   test("A1 Addressing absolute", async () => {
@@ -54,6 +120,12 @@ describe("Unit tests", () => {
 });
 
 describe("Spreadsheet builder", () => {
+  // The expected csv depends on how LibreOffice renders numbers, dates and currencies,
+  // which follows its locale. Both the profile and the environment are pinned so the
+  // tests do not depend on whatever locale the machine running them happens to use.
+  const userProfile = "__tests__/output/libreoffice-profile";
+  const locale = "en_US.UTF-8";
+
   beforeAll(async () => {
     await rm("__tests__/output", { recursive: true, force: true });
     await mkdir("__tests__/output");
@@ -66,7 +138,10 @@ describe("Spreadsheet builder", () => {
     // todo: see why this did not work using execa
 
     const e = promisify(exec);
-    const p = await e(`libreoffice --headless --convert-to csv:"Text - txt - csv (StarCalc)":"44,34,76,1,,1031,true,true" __tests__/output/${name}.fods --outdir __tests__/output`);
+    const p = await e(
+      `libreoffice -env:UserInstallation=file://${resolve(userProfile)} --headless --convert-to csv:"Text - txt - csv (StarCalc)":"44,34,76,1,,1031,true,true" __tests__/output/${name}.fods --outdir __tests__/output`,
+      { env: { ...process.env, LANG: locale, LC_ALL: locale } },
+    );
 
     expect(p.stderr).toEqual("");
 
@@ -124,6 +199,13 @@ describe("Spreadsheet builder", () => {
 
     const spreadsheet = [['<xml is="a thing">', "foo & bar"]];
     await integrationTest("cdata", spreadsheet, expectedCsv);
+  });
+
+  test("CDATA terminator in a cell value", async () => {
+    const expectedCsv = `"a]]> b","]]>"\n`;
+
+    const spreadsheet = [["a]]> b", "]]>"]];
+    await integrationTest("cdata-terminator", spreadsheet, expectedCsv);
   });
 
   test("Formula", async () => {

--- a/src/spreadsheet.ts
+++ b/src/spreadsheet.ts
@@ -31,44 +31,71 @@ function buildTableRows(s: spreadsheetInput): string {
   return s.map(mapRows).join("\n");
 }
 
+type cellPosition = { rowIndex: number; cellIndex: number };
+
 function buildNamedRanges(s: spreadsheetInput): string {
-  const rangeNamesIndexed = s.flatMap((r, ri) =>
-    r.map((c, ci) => {
-      return { range: typeof c === "string" ? undefined : c.range, rowIndex: ri + 1, cellIndex: ci + 1 };
+  const cellsGroupedByNamedRanges = new Map<string, cellPosition[]>();
+  s.forEach((r, ri) =>
+    r.forEach((c, ci) => {
+      const range = typeof c === "string" ? undefined : c.range;
+      if (range === undefined) {
+        return;
+      }
+      const group = cellsGroupedByNamedRanges.get(range) ?? [];
+      group.push({ rowIndex: ri + 1, cellIndex: ci + 1 });
+      cellsGroupedByNamedRanges.set(range, group);
     }),
   );
 
-  // via mdn: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#grouping_objects_by_a_property
-  function groupBy(objectArray: any[], property: string) {
-    return objectArray.reduce((acc, obj) => {
-      const key = obj[property];
-      const curGroup = acc[key] ?? [];
+  /**
+   * Address of the smallest rectangle containing all cells of the group.
+   * A named range is a single rectangle, so a group which does not fill its
+   * bounding box would silently pull in cells the caller never assigned to it.
+   */
+  function cellRangeAddress(name: string, cells: cellPosition[]): string {
+    const firstColumn = Math.min(...cells.map((c) => c.cellIndex));
+    const lastColumn = Math.max(...cells.map((c) => c.cellIndex));
+    const firstRow = Math.min(...cells.map((c) => c.rowIndex));
+    const lastRow = Math.max(...cells.map((c) => c.rowIndex));
 
-      return { ...acc, [key]: [...curGroup, obj] };
-    }, {});
-  }
-
-  const cellsGroupedByNamedRanges = groupBy(rangeNamesIndexed, "range");
-
-  const namedRanges = Object.keys(cellsGroupedByNamedRanges).filter((x) => x !== "undefined");
-
-  function cellRangeAddress(arr: any[]): string {
-    if (arr.length == 1) {
-      return `.${A1(arr[0].cellIndex, arr[0].rowIndex, "columnAndRow")}`;
+    const boundingBoxSize = (lastColumn - firstColumn + 1) * (lastRow - firstRow + 1);
+    if (boundingBoxSize !== cells.length) {
+      throw new Error(
+        `Named range '${name}' is not contiguous: its cells do not fill the rectangle ${A1(firstColumn, firstRow)}:${A1(lastColumn, lastRow)}. A named range must cover a full rectangle of cells.`,
+      );
     }
-    return `.${A1(arr[0].cellIndex, arr[0].rowIndex, "columnAndRow")}:.${A1(arr[arr.length - 1].cellIndex, arr[arr.length - 1].rowIndex, "columnAndRow")}`;
+
+    if (cells.length == 1) {
+      return `.${A1(firstColumn, firstRow, "columnAndRow")}`;
+    }
+    return `.${A1(firstColumn, firstRow, "columnAndRow")}:.${A1(lastColumn, lastRow, "columnAndRow")}`;
   }
 
-  const namedRangesXmlStrings = namedRanges.map(
-    (r) =>
-      `<table:named-range table:name="${r}" table:base-cell-address="$Sheet1.${A1(
-        cellsGroupedByNamedRanges[r][0].cellIndex,
-        cellsGroupedByNamedRanges[r][0].rowIndex,
+  const namedRangesXmlStrings = [...cellsGroupedByNamedRanges].map(
+    ([name, cells]) =>
+      `<table:named-range table:name="${attribute(name)}" table:base-cell-address="$Sheet1.${A1(
+        cells[0].cellIndex,
+        cells[0].rowIndex,
         "columnAndRow",
-      )}" table:cell-range-address="$Sheet1${cellRangeAddress(cellsGroupedByNamedRanges[r])}"/>`,
+      )}" table:cell-range-address="$Sheet1${cellRangeAddress(name, cells)}"/>`,
   );
 
   return namedRangesXmlStrings.join("\n");
+}
+
+/**
+ * Wrap a value in a CDATA section, splitting it up where it contains the
+ * terminator `]]>` which a single section cannot carry.
+ */
+function cdata(value: string): string {
+  return `<![CDATA[${value.split("]]>").join("]]]]><![CDATA[>")}]]>`;
+}
+
+/**
+ * Escape a value which is interpolated into an XML attribute
+ */
+function attribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 function mapRows(value: row): string {
@@ -81,7 +108,7 @@ function mapCells(value: cell): string {
 
 function tableCellElement(cell: cell): string {
   if (typeof cell == "string") {
-    return `<table:table-cell office:value-type="string" calcext:value-type="string"> <text:p><![CDATA[${cell}]]></text:p> </table:table-cell>`;
+    return `<table:table-cell office:value-type="string" calcext:value-type="string"> <text:p>${cdata(cell)}</text:p> </table:table-cell>`;
   }
 
   if ("functionName" in cell) {
@@ -114,7 +141,7 @@ function tableCellElement(cell: cell): string {
     return `<table:table-cell office:value="${cell.value}" table:style-name="PERCENTAGE_STYLE" office:value-type="percentage" calcext:value-type="percentage" />`;
   }
 
-  return `<table:table-cell office:value-type="string" calcext:value-type="string"> <text:p><![CDATA[${cell.value}]]></text:p> </table:table-cell>`;
+  return `<table:table-cell office:value-type="string" calcext:value-type="string"> <text:p>${cdata(cell.value)}</text:p> </table:table-cell>`;
 }
 
 type addressAbsolute = "none" | "column" | "row" | "columnAndRow";
@@ -136,11 +163,21 @@ export function A1(column: number, row: number, absolute: addressAbsolute = "non
   return `${absolute === "column" || absolute === "columnAndRow" ? "$" : ""}${columnIndex(column)}${absolute === "row" || absolute === "columnAndRow" ? "$" : ""}${row}`;
 }
 
+/**
+ * Return the spreadsheet column name for a one-indexed column number
+ * @param i one-indexed column number
+ * @returns String like 'A', 'Z', 'AA' or 'AAA'
+ */
 export function columnIndex(i: number): string {
   if (i < 1) {
     throw new Error(`Minimal value is 1, actual value is ${i}`);
   }
-  return String.fromCharCode(64 + i);
+  // bijective base-26: A..Z, AA..AZ, BA..ZZ, AAA..
+  let name = "";
+  for (let rest = i; rest > 0; rest = Math.floor((rest - 1) / 26)) {
+    name = String.fromCharCode(65 + ((rest - 1) % 26)) + name;
+  }
+  return name;
 }
 
 const FODS_TEMPLATE = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Addresses four open issues, each developed red-green: a failing test first, then the fix.

### Fixes #414 — `columnIndex()` produces invalid addresses beyond column Z

`String.fromCharCode(64 + i)` only covers the first 26 columns; column 27 silently became `[`. Replaced with proper bijective base-26. Tests cover 26/27/28/52/53/702/703 and the `A1()` cases built on top.

### Fixes #415 — string cell containing `]]>` corrupts the document

The value was interpolated straight into a CDATA section, so a `]]>` in the data closed the section early and leaked the rest into the XML as markup. Values are now split across multiple CDATA sections (`]]]]><![CDATA[>`). Range names interpolated into attributes are escaped as well.

Formula `arguments` are deliberately left raw: the README and the `ARABIC` test pass pre-escaped entities (`&quot;`) through them, so escaping there would be a breaking change and deserves its own decision.

### Fixes #418 — named range on non-contiguous cells emits a wrong rectangular address

The address was built from the first and last cell of the group, so a name applied to e.g. A1 and C3 silently widened into a rectangle swallowing seven cells the caller never assigned. The address is now the bounding box, and a group which does not fill that box is rejected with an error naming the range.

Also covers the cleanups listed in the issue: the two `no-explicit-any` lint warnings are gone, the O(n²) `groupBy` is a `Map`, and a range literally named `"undefined"` is no longer dropped.

### Fixes #416 — integration tests are not hermetic

Worth flagging: these tests were already failing on any machine whose LibreOffice profile is not en-US, independent of the changes above — a profile with `ooSetupSystemLocale = de-DE` renders `1,00` where the assertions expect `1.00`. They now run against a throwaway profile under `__tests__/output/` with `LANG`/`LC_ALL` pinned.

One caveat: this assumes `en_US.UTF-8` is generated on the host. It works locally and on the CI image, but a machine with only `C.UTF-8` would fail differently than before. The host-independent alternative is to pin the locale in the FODS number styles instead — happy to switch if you prefer that.

### Verification

`jest` 22 passed / 22 total, plus `tsc --noEmit`, prettier and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)