### PR TITLE
Upgrade to TypeScript 6 and modernise the compiler target

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -3,7 +3,7 @@
   "moduleFileExtensions": ["js", "ts"],
   "testMatch": ["**/*.test.ts", "**/*.spec.ts"],
   "transform": {
-    "^.+\\.ts$": "ts-jest"
+    "^.+\\.ts$": ["ts-jest", { "tsconfig": "tsconfig.test.json" }]
   },
   "verbose": true,
   "testTimeout": 100000

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "scripts": {
     "test": "jest",
     "build": "tsc",
-    "lint:check": "eslint . --ext .ts,.tsx",
+    "lint:check": "eslint . --ext .ts",
     "lint": "npm run lint:check -- --fix",
-    "_format": "prettier '**/*.{ts,tsx,json,md}'",
+    "_format": "prettier '**/*.{ts,json,md}'",
     "format": "npm run _format -- --write",
     "format:check": "npm run _format -- --list-different",
     "all": "yarn run build && yarn run format && yarn run lint && yarn test",
@@ -21,10 +21,10 @@
     "convert-test-files": "ts-node convert-test-output-formats.ts"
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
+    "*.ts": [
       "eslint --fix"
     ],
-    "*.{ts,tsx,json,md}": [
+    "*.{ts,json,md}": [
       "prettier --write"
     ]
   },
@@ -52,7 +52,7 @@
     "prettier": "^3.0.0",
     "ts-jest": "^29.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.2"
+    "typescript": "^6.0.3"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,20 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "target": "es5",
-    "lib": ["es2015", "DOM"],
+    "target": "es2022",
+    "lib": ["es2022"],
+    "types": ["node"],
     "esModuleInterop": true,
     "declaration": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "sourceMap": true,
     "newLine": "LF",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "incremental": true,
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "strict": true,
-    "downlevelIteration": true,
-    "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"]

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["src", "__tests__", "convert-test-output-formats.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3132,10 +3132,10 @@ type-fest@^4.41.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
   integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
-typescript@^5.0.2:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
Fixes #417. Unblocks #387 (dependabot's typescript 5.9.3 -> 6.0.3).

Reproduced the reported failure first, against tsc 6.0.3 and the current config:

```
tsconfig.json(4,15):  error TS5107: Option 'target=ES5' is deprecated ...
tsconfig.json(15,5):  error TS5101: Option 'downlevelIteration' is deprecated ...
```

As the issue suggests, the target moves to `es2022` rather than silencing the deprecations with `ignoreDeprecations`. This is a Node library, so `es5` and the `downlevelIteration` it forces had no reason to be here; both deprecated options simply go away, and `dist` loses its downlevel helpers.

Also removed, per the issue: `"jsx": "react-jsx"`, `DOM` from `lib`, and the `.tsx` globs in `lint:check`, `_format` and `lint-staged`.

### Two things the issue did not anticipate

Both fell out of the changes above and are worth a look during review:

- **`console` came from the DOM lib.** With DOM gone it should have come from `@types/node`, but tsc 6 no longer picks that up automatically here. `types` is now set explicitly to `["node"]`, which is the right thing for a Node library anyway. That in turn hides `@types/jest` from the tests, so they get a `tsconfig.test.json` extending the base and adding the jest types, with ts-jest pointed at it.
- **tsc 6 requires `rootDir` to be explicit when emitting** (TS5011), and no longer places `tsconfig.tsbuildinfo` inside `outDir` on its own. Both are now set explicitly, so `dist` is laid out exactly as before and the existing `!dist/tsconfig.tsbuildinfo` entry in `files` still matches.

### Verification

`tsc`, `eslint`, `prettier --check`, the `ts-node` convert script and `jest` all run.

Six integration tests fail on this branch, but they are the ambient LibreOffice locale problem (#416), not this change — they fail on `main` too. Merged locally with the branch from #421 that fixes it, the full suite is 22/22 green.

The two remaining `no-explicit-any` eslint warnings are also pre-existing and cleaned up in #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)